### PR TITLE
Documentation copy-editing

### DIFF
--- a/specification/definitions/index.html
+++ b/specification/definitions/index.html
@@ -911,7 +911,7 @@
 
 <h2 id="paymentconfirmation">PaymentConfirmation</h2>
 
-<p>Confirm that a previous {@link PaymentRequest} has completed successfully at the POS. Where possible all optional fields should be supplied to ensure smooth processing. If optional fields are not present then processing may require retrieval of the original transaction leading to unnecessary processing overheads.
+<p>Confirm that a previous <a href="#paymentrequest">PaymentRequest</a> has completed successfully at the POS. Where possible all optional fields should be supplied to ensure smooth processing. If optional fields are not present then processing may require retrieval of the original transaction leading to unnecessary processing overheads.
 <table border="1">
     <tr>
         <th>Name</th>

--- a/specification/operations/index.html
+++ b/specification/operations/index.html
@@ -459,7 +459,7 @@
 
 <p><strong>POST /payments/confirmations</strong></p>
 
-<p>This operation confirms that a QR payment transaction has completed successfully between the consumer and the merchant. Such a transaction may may be settled between the merchant and the Partner that processed the payment. Such a transaction cannot be reversed.</p>
+<p>This operation confirms that a QR payment transaction has completed successfully between the consumer and the merchant. Such a transaction may be settled between the merchant and the Partner that processed the payment. Such a transaction cannot be reversed.</p>
 
 <h4 id="security-1">Security</h4>
 
@@ -551,7 +551,7 @@
 
 <p><strong>POST /payments/reversals</strong></p>
 
-<p>This operation indicates that the sale did not complete and the payment should be reversed if it took place. Once a payment is reversed it canot be confirmed and need not be settled between the merchant and the QR Partner.</p>
+<p>This operation indicates that the sale did not complete and the payment should be reversed if it took place. Once a payment is reversed it cannot be confirmed and need not be settled between the merchant and the QR Partner.</p>
 
 <h4 id="security-2">Security</h4>
 


### PR DESCRIPTION
The `{@link }` error likely needs to be fixed in whatever is used to generate the html for this site, however there are copy-editing issues in the text in said generation files.